### PR TITLE
Remove Jaeger and ArgoRollouts from the initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Before you begin, ensure the following tools are installed and running on your l
 3. Open the Command Palette (F1 or Ctrl+Shift+P) and select `Remote-Containers: Reopen in Container`. This will build and open the repository in a Docker-based development container.
 
 ### Step 2: Set OpenAI Connection Details
+
 Once inside the development container, set up the necessary environment variables for OpenAI API access in the `.env` file.
 This OpenAPI access is used by the `lmos-runtime` and the agents.
 
@@ -102,13 +103,11 @@ kubectl get channelrouting acme-web-stable -o yaml
 
 ### Step 4: Access Kiali and Grafana
 
-To visualize your setup, various ports have been forwarded for LMOS, Kiali, Prometheus, Jaeger, Grafana and ArgoCD. You can access these tools at
+To visualize your setup, various ports have been forwarded for LMOS, Kiali, Prometheus and Grafana. You can access these tools at
 
 - Kiali: http://localhost:20001
 - Grafana: http://localhost:3000
 - Prometheus: http://localhost:9090
-- Jaeger: http://localhost:9411
-- ArgoCD: http://localhost:3100
 - LMOS Runtime: http://localhost:8081
 - Arc View: http://localhost:8080
 
@@ -133,7 +132,7 @@ You will see that the weather-agent has responded.
 
 ## Using ArgoCD for deployment
 
-You can add the `argocd-apps` folder as new ArgoCD Application to your existing cluster ArgoCD managed cluster. You only need to adapt the secrets.yaml. 
+You can add the `argocd-apps` folder as new ArgoCD application to your existing cluster ArgoCD managed cluster. You only need to adapt the secrets.yaml. 
 
 ## Code of Conduct
 

--- a/init/install_services.sh
+++ b/init/install_services.sh
@@ -16,7 +16,6 @@ kubectl apply -f istio/istio-operator.yaml
 #istioctl install --set profile=demo -y
 kubectl apply -f ${ISTIO_HOME}/samples/addons/prometheus.yaml
 kubectl apply -f ${ISTIO_HOME}/samples/addons/grafana.yaml
-kubectl apply -f ${ISTIO_HOME}/samples/addons/jaeger.yaml
 kubectl apply -f ${ISTIO_HOME}/samples/addons/kiali.yaml
 
 # Label the default namespace for Istio sidecar injection
@@ -62,17 +61,14 @@ echo "Waiting for pods to be running..."
 while ! kubectl get pods -n istio-system | grep kiali | grep -q Running; do sleep 1; done
 while ! kubectl get pods -n istio-system | grep grafana | grep -q Running; do sleep 1; done
 while ! kubectl get pods -n istio-system | grep prometheus | grep -q Running; do sleep 1; done
-while ! kubectl get pods -n istio-system | grep jaeger | grep -q Running; do sleep 1; done
 while ! kubectl get pods | grep lmos-runtime | grep -q Running; do sleep 1; done
 while ! kubectl get pods | grep arc-view-runtime-web | grep -q Running; do sleep 1; done
 
 # Set up port forwarding
 echo "Setting up port forwarding..."
-nohup kubectl argo rollouts dashboard >/dev/null 2>&1 &
 nohup kubectl -n istio-system port-forward svc/kiali 20001:20001 >/dev/null 2>&1 &
 nohup kubectl -n istio-system port-forward svc/grafana 3000:3000 >/dev/null 2>&1 &
 nohup kubectl -n istio-system port-forward svc/prometheus 9090:9090 >/dev/null 2>&1 &
-nohup kubectl -n istio-system port-forward svc/tracing 9411:80 >/dev/null 2>&1 &
 nohup kubectl port-forward svc/lmos-runtime 8081:8081 >/dev/null 2>&1 &
 nohup kubectl port-forward svc/arc-view-runtime-web-service 8080:80 >/dev/null 2>&1 &
 


### PR DESCRIPTION
These services are not useful for the basic demo setup.
ArgoRollouts should be shown as a dedicated demo use case instead.