### PR TITLE
Move from istio operator to istio install to support latest istio version

### DIFF
--- a/init/install_services.sh
+++ b/init/install_services.sh
@@ -8,9 +8,8 @@
 #set -e
 
 source .env
-
 # Install Istio with the default profile and debug logging level
-istioctl operator init
+istioctl install -y
 kubectl apply -f istio/istio-operator.yaml
 
 #istioctl install --set profile=demo -y


### PR DESCRIPTION
Istio 1.24 removed the deprecated istio operator command:
https://istio.io/latest/blog/2024/in-cluster-operator-deprecation-announcement/

For that we have to use istio install as replacement