### PR TITLE
Introduce starter demo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,10 +13,10 @@
     }
   },
   "runArgs": [
-    "--memory=8g",   // Allocate 8 GB of memory to the DevContainer
+    "--memory=6g",   // Allocate 6 GB of memory to the DevContainer
     "--cpus=4"        // Allocate 4 CPUs to the DevContainer
   ],
-  "postCreateCommand": "./init/start_minikube.sh && ./init/install_services.sh",
+  "postCreateCommand": "./init/start_minikube.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before you begin, ensure the following tools are installed and running on your l
 
 2. Open the repository in Visual Studio Code:
 
-3. Open the Command Palette (F1 or Ctrl+Shift+P) and select `Remote-Containers: Reopen in Container`. This will build and open the repository in a Docker-based development container.
+3. Open the Command Palette (F1 or Ctrl+Shift+P) and select `Remote-Containers: Reopen in Container`. This will build and open the repository in a Docker-based development container, in which Minikube is already installed and started.
 
 ### Step 2: Set OpenAI Connection Details
 
@@ -35,6 +35,14 @@ OPENAI_MODELNAME="gpt-4o-mini"
 OPENAI_URL="https://api.openai.com"
 ```
 
+### Step 3: Install LMOS
+
+Run the following commands to install LMOS onto Minikube:
+
+```shell
+./install.sh
+```
+
 ### Step 3: Check the Setup
 
 To verify the installation of LMOS, run:
@@ -46,60 +54,13 @@ kubectl get pods
 Output:
 
 ```
-NAME                               READY   STATUS    RESTARTS   AGE
-lmos-operator-c45887647-bcwf8      2/2     Running   0          4m16s
-lmos-runtime-85654bc6bc-chvrj      2/2     Running   0          4m15s
+NAME                                   READY   STATUS    RESTARTS   AGE
+arc-view-runtime-web-db8d87c59-54k7b   2/2     Running   0          87s
+lmos-operator-64bfb9b569-4l9qv         2/2     Running   0          2m22s
+lmos-runtime-59ffdbdc6f-v5jtr          2/2     Running   0          2m21s
 ```
 
-The status has to be `2/2 Running`.
-
-Two agents have been installed, you can list them with 
-
-```
-kubectl get agents
-```
-
-Output:
-
-```
-NAME                AGE
-arc-news-agent      2m34s
-arc-weather-agent   2m35s
-```
-
-One channel has been defined, using the capability of the weather-agent.
-
-You can list available channels with the following command:
-
-```
-kubectl get channels
-```
-
-Output:
-
-```
-NAME               RESOLVE_STATUS
-acme-web-stable    RESOLVED
-```
-
-The `RESOLVE_STATUS` of the channel has to be `RESOLVED`, which means the required capabilities have been resolved.
-If the status is `UNRESOLVED`, you can check the reason with: 
-
-```
-kubectl get channel acme-web-stable -o yaml
-```
-
-You can list the resolved channelroutings with:
-
-```
-kubectl get channelroutings
-```
-
-And look at a specific channel routing with:
-
-```
-kubectl get channelrouting acme-web-stable -o yaml
-```
+The status has to be `2/2 Running` for all three of them.
 
 ### Step 4: Access Kiali and Grafana
 
@@ -108,27 +69,19 @@ To visualize your setup, various ports have been forwarded for LMOS, Kiali, Prom
 - Kiali: http://localhost:20001
 - Grafana: http://localhost:3000
 - Prometheus: http://localhost:9090
-- LMOS Runtime: http://localhost:8081
-- Arc View: http://localhost:8080
 
-### Step 5: Execute a POST request
+The LMOS components can be accessed at:
+- Arc View: http://localhost:8080 (Web)
+- LMOS Runtime: http://localhost:8081 (API)
 
-You can use Postman or the `test_runtime.sh` script to send a test request to the LMOS runtime. 
-The `lmos-runtime` is uses the `lmos-router` to route the request to the appropriate agent.
+### Step 5: Install a demo
 
-To test the weather agent, run:
+In the `demos` folder, you can find various demo setups.
+To install a demo, run the corresponding `install.sh` script, e.g. for the `starter` demo:
 
+```shell
+./demos/starter/install.sh
 ```
-./test_runtime.sh
-```
-
-Output:
-
-```
-{"content":"The weather in London is 21 degrees."}
-```
-
-You will see that the weather-agent has responded. 
 
 ## Using ArgoCD for deployment
 

--- a/demos/product-recommender/install.sh
+++ b/demos/product-recommender/install.sh
@@ -13,9 +13,9 @@ source "$SCRIPT_DIR/.env"
 # Update openai-secrets through kubectl by adding the .env variables to the existing secrets
 kubectl create secret generic openai-secrets --from-env-file="$SCRIPT_DIR/.env" --dry-run=client -o yaml | kubectl apply -f -
 
-helm upgrade --install productsearch-agent oci://ghcr.io/lmos-ai/productsearch-agent-chart --version 0.1.0-SNAPSHOT
-helm upgrade --install techspec-agent oci://ghcr.io/lmos-ai/techspec-agent-chart --version 0.1.1-SNAPSHOT
-helm upgrade --install --wait reportgenerate-agent oci://ghcr.io/lmos-ai/reportgenerate-agent-chart --version 0.1.0-SNAPSHOT
+helm upgrade --install productsearch-agent oci://ghcr.io/lmos-ai/productsearch-agent-chart --version 0.1.0
+helm upgrade --install techspec-agent oci://ghcr.io/lmos-ai/techspec-agent-chart --version 0.1.1
+helm upgrade --install --wait reportgenerate-agent oci://ghcr.io/lmos-ai/reportgenerate-agent-chart --version 0.1.0
 
 #Port Forward
 nohup kubectl port-forward svc/reportgenerate-agent 8082:8080 >/dev/null 2>&1 &

--- a/demos/starter/README.md
+++ b/demos/starter/README.md
@@ -1,0 +1,70 @@
+# Starter Demo
+
+This demo shows how to install a simple demo setup with two agents and a channel.
+The agents are a news agent and a weather agent. The channel is a web channel that uses both agents.
+
+## Prerequisites
+
+The initial setup of LMOS should be completed before installing the services for the starter demo.
+
+## Installing the demo
+
+Execute the following command to install the services for the starter demo:
+```
+./demos/starter/install.sh 
+```
+
+## Check the Setup
+
+Two agents have been installed, you can list them with 
+
+```
+kubectl get agents
+```
+
+Output:
+
+```
+NAME                AGE
+arc-news-agent      2m34s
+arc-weather-agent   2m35s
+```
+
+One channel has been defined, using the capability of the weather-agent.
+
+You can list available channels with the following command:
+
+```
+kubectl get channels
+```
+
+Output:
+
+```
+NAME               RESOLVE_STATUS
+acme-web-stable    RESOLVED
+```
+
+The `RESOLVE_STATUS` of the channel has to be `RESOLVED`, which means the required capabilities have been resolved.
+If the status is `UNRESOLVED`, you can check the reason with: 
+
+```
+kubectl get channel acme-web-stable -o yaml
+```
+
+You can list the resolved channelroutings with:
+
+```
+kubectl get channelroutings
+```
+
+And look at a specific channel routing with:
+
+```
+kubectl get channelrouting acme-web-stable -o yaml
+```
+
+### Example Usage
+
+1. Use this URL http://localhost:8080/ to open arc-view web.
+2. Type any query in the input box and press enter.

--- a/demos/starter/acme-web-stable-channel.yml
+++ b/demos/starter/acme-web-stable-channel.yml
@@ -14,4 +14,6 @@ metadata:
 spec:
   requiredCapabilities:
     - name: get-weather-forecast
-      version: ">=1.0.4"
+      version: ">=1.0.7"
+    - name: get-news
+      version: ">=1.0.7"

--- a/demos/starter/install.sh
+++ b/demos/starter/install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Exit immediately if a command exits with a non-zero status
+#set -e
+
+SCRIPT_DIR=$(dirname "$0")
+source "$SCRIPT_DIR/../../.env"
+
+# Install agents
+kubectl delete secret openai-secrets 2>/dev/null
+kubectl create secret generic openai-secrets \
+    --from-literal=ARC_AI_CLIENTS_0_APIKEY="$OPENAI_APIKEY" \
+    --from-literal=ARC_AI_CLIENTS_0_MODELNAME="$OPENAI_MODELNAME" \
+    --from-literal=ARC_AI_CLIENTS_0_URL="$OPENAI_URL" \
+    --from-literal=ARC_AI_CLIENTS_0_ID="OPENAI" \
+    --from-literal=ARC_AI_CLIENTS_0_CLIENT="$OPENAI_CLIENTNAME"
+
+helm upgrade --install weather-agent oci://ghcr.io/lmos-ai/weather-agent-chart --version 1.0.7
+helm upgrade --install news-agent oci://ghcr.io/lmos-ai/news-agent-chart --version 1.0.7
+
+echo "Setting up channel..."
+# Stable Channel – Includes the weather agent and news agent
+kubectl apply -f "$SCRIPT_DIR/acme-web-stable-channel.yml"

--- a/install.sh
+++ b/install.sh
@@ -40,18 +40,6 @@ echo "Waiting for LMOS agent CRD to be created..."
 while ! kubectl get crd agents.lmos.ai >/dev/null 2>/dev/null; do sleep 1; done
 echo "LMOS agent CRD created."
 
-# Install agents
-kubectl delete secret openai-secrets 2>/dev/null
-kubectl create secret generic openai-secrets \
-    --from-literal=ARC_AI_CLIENTS_0_APIKEY="$OPENAI_APIKEY" \
-    --from-literal=ARC_AI_CLIENTS_0_MODELNAME="$OPENAI_MODELNAME" \
-    --from-literal=ARC_AI_CLIENTS_0_URL="$OPENAI_URL" \
-    --from-literal=ARC_AI_CLIENTS_0_ID="OPENAI" \
-    --from-literal=ARC_AI_CLIENTS_0_CLIENT="$OPENAI_CLIENTNAME"
-
-helm upgrade --install weather-agent oci://ghcr.io/lmos-ai/weather-agent-chart --version 1.0.7-SNAPSHOT
-helm upgrade --install news-agent oci://ghcr.io/lmos-ai/news-agent-chart --version 1.0.7-SNAPSHOT
-
 # Install arc-view chart
 helm upgrade --install arc-view-runtime-web oci://ghcr.io/lmos-ai/arc-view-runtime-web-chart --version 0.1.0
 
@@ -70,10 +58,6 @@ nohup kubectl -n istio-system port-forward svc/grafana 3000:3000 >/dev/null 2>&1
 nohup kubectl -n istio-system port-forward svc/prometheus 9090:9090 >/dev/null 2>&1 &
 nohup kubectl port-forward svc/lmos-runtime 8081:8081 >/dev/null 2>&1 &
 nohup kubectl port-forward svc/arc-view-runtime-web-service 8080:80 >/dev/null 2>&1 &
-
-echo "Setting up channel..."
-# Stable Channel – Includes only the weather agent
-kubectl apply -f init/acme-web-stable-channel.yml
 
 # Route 100% of traffic to stable channels
 kubectl apply -f istio/vsvc-stable.yaml


### PR DESCRIPTION
- move weather and news agent out of the initial setup and into a "starter" demo
- do not use snapshot versions of agents
- introduce a dedicated "install" step for LMOS, which should be run after the user has set up the OpenAI api key